### PR TITLE
Add CropImage

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,7 +207,8 @@
 - [NukeUI](https://github.com/kean/NukeUI) - Lazy image loading for SwiftUI
 - [SwURL](https://github.com/cmtrounce/SwURL) - Lightweight asynchronous image loading in SwiftUI. Fetch and display images from URLs.
 - [CachedAsyncImage](https://github.com/lorenzofiamingo/SwiftUI-CachedAsyncImage) - 🗃️ The simplest way to add cache to your AsyncImage.
-- [swiftui-image-viewer](https://github.com/Jake-Short/swiftui-image-viewer) - Image viewer built in SwiftUI for both local and remote images 
+- [swiftui-image-viewer](https://github.com/Jake-Short/swiftui-image-viewer) - Image viewer built in SwiftUI for both local and remote images
+- [CropImage](https://github.com/laosb/CropImage) - A pure SwiftUI view where user can move and resize an image to a pre-defined size.
 
 ## List
 [scroll to top](#readme) 


### PR DESCRIPTION
Hello,

I'm the author of `CropImage`, a SwiftUI view where user can move and resize an image to a pre-defined size.

- Supports iOS, visionOS and macOS
- Use ImageRenderer to render the cropped image, when possible
- Very lightweight
- (Optionally) bring your own crop UI 

Hope you find this useful. This package is used in production apps since its creation and performs quite well for our use cases.